### PR TITLE
feat: rename clear() to erase() to un-shadow DrawTarget::clear(Color)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### ⚠️ Breaking
+
+* Renamed `DmaFrameBuffer::clear()` to `erase()`.  
+  The new name avoids shadowing `embedded_graphics::DrawTarget::clear(Color)`.  
+  Update your code: `fb.clear()` ➜ `fb.erase()`.  
+  If you actually wanted the trait method, call `fb.clear(Color::BLACK)` instead.
+
 ### Added
 
 - `skip-black-pixels` feature that gives a performance boot in some cases (#2)
 
 ### Changed
-
 - almost double(!) performance of the set_pixel in the plain and latched `DmaFrameBuffers` (#2)
-- small performance gain in clear() in the plain and latched `DmaFrameBuffers` (#3)
 
 ## [0.1.0] - 2025-06-14
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,19 +46,19 @@ criterion = "0.6"
 bench = false
 
 [[bench]]
-name = "set_pixel_latched"
-harness = false
-
-[[bench]]
 name = "set_pixel_plain"
 harness = false
 
 [[bench]]
-name = "clear_plain"
+name = "set_pixel_latched"
 harness = false
 
 [[bench]]
-name = "clear_latched"
+name = "erase_plain"
+harness = false
+
+[[bench]]
+name = "erase_latched"
 harness = false
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -63,9 +63,14 @@ const BITS:       u8    = 3;               // colour depth ⇒ 7 BCM frames
 const NROWS:      usize = compute_rows(ROWS);          // 16
 const FRAME_COUNT:usize = compute_frame_count(BITS);   // (1<<BITS)-1 = 7
 
-// Create & clear a framebuffer
-let mut fb = DmaFrameBuffer::<ROWS, COLS, NROWS, BITS, FRAME_COUNT>::new();
-fb.clear();
+// Create a framebuffer (already initialized/cleared)
+let mut framebuffer = DmaFrameBuffer::<ROWS, COLS, NROWS, BITS, FRAME_COUNT>::new();
+
+// Draw a red rectangle
+Rectangle::new(Point::new(10, 10), Size::new(20, 20))
+    .into_styled(PrimitiveStyle::with_fill(Color::RED))
+    .draw(&mut framebuffer)
+    .unwrap();
 ```
 
 You can now draw using any `embedded-graphics` primitive:
@@ -77,11 +82,13 @@ use hub75_framebuffer::Color;
 
 Rectangle::new(Point::new(0, 0), Size::new(COLS as u32, ROWS as u32))
     .into_styled(PrimitiveStyle::with_fill(Color::BLACK))
-    .draw(&mut fb)?;
+    .draw(&mut framebuffer)
+    .unwrap();
 
 Circle::new(Point::new(20, 10), 8)
     .into_styled(PrimitiveStyle::with_fill(Color::GREEN))
-    .draw(&mut fb)?;
+    .draw(&mut framebuffer)
+    .unwrap();
 ```
 
 Finally hand the raw DMA buffer off to your MCU's parallel peripheral.

--- a/benches/erase_latched.rs
+++ b/benches/erase_latched.rs
@@ -1,7 +1,7 @@
-// Run with:  cargo bench --bench clear_plain
+// Run with:  cargo bench --bench clear_latched
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use hub75_framebuffer::plain::DmaFrameBuffer;
+use hub75_framebuffer::latched::DmaFrameBuffer;
 use std::hint::black_box;
 use std::time::Duration;
 
@@ -23,26 +23,19 @@ fn configure_criterion() -> Criterion {
         .significance_level(0.05)
 }
 
-fn clear_plain(c: &mut Criterion) {
-    let mut group = c.benchmark_group("clear_plain");
+fn erase_latched(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Latched Implementation");
+
     group.throughput(Throughput::Elements(
         (ROWS * COLS * FRAME_COUNT * ITERATIONS) as u64,
     ));
 
-    group.bench_function("plain_dma_framebuffer_clear", |b| {
-        // Create a formatted framebuffer once
+    group.bench_function("erase", |b| {
         let mut fb = DmaFrameBuffer::<ROWS, COLS, NROWS, BITS, FRAME_COUNT>::new();
-
-        b.iter(|| {
-            // Benchmark multiple clear operations to make measurements longer and more stable
-            for _ in 0..ITERATIONS {
-                black_box(&mut fb).clear();
-            }
-        });
+        b.iter(|| black_box(&mut fb).erase());
     });
-
     group.finish();
 }
 
-criterion_group!(name = benches; config = configure_criterion(); targets = clear_plain);
+criterion_group!(name = benches; config = configure_criterion(); targets = erase_latched);
 criterion_main!(benches);

--- a/benches/erase_plain.rs
+++ b/benches/erase_plain.rs
@@ -1,7 +1,7 @@
-// Run with:  cargo bench --bench clear_latched
+// Run with:  cargo bench --bench clear_plain
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use hub75_framebuffer::latched::DmaFrameBuffer;
+use hub75_framebuffer::plain::DmaFrameBuffer;
 use std::hint::black_box;
 use std::time::Duration;
 
@@ -23,26 +23,23 @@ fn configure_criterion() -> Criterion {
         .significance_level(0.05)
 }
 
-fn clear_latched(c: &mut Criterion) {
-    let mut group = c.benchmark_group("clear_latched");
+fn erase_plain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Plain Implementation");
     group.throughput(Throughput::Elements(
         (ROWS * COLS * FRAME_COUNT * ITERATIONS) as u64,
     ));
 
-    group.bench_function("latched_dma_framebuffer_clear", |b| {
+    group.bench_function("erase", |b| {
         // Create a formatted framebuffer once
         let mut fb = DmaFrameBuffer::<ROWS, COLS, NROWS, BITS, FRAME_COUNT>::new();
 
         b.iter(|| {
-            // Benchmark multiple clear operations to make measurements longer and more stable
-            for _ in 0..ITERATIONS {
-                black_box(&mut fb).clear();
-            }
+            black_box(&mut fb).erase();
         });
     });
 
     group.finish();
 }
 
-criterion_group!(name = benches; config = configure_criterion(); targets = clear_latched);
+criterion_group!(name = benches; config = configure_criterion(); targets = erase_plain);
 criterion_main!(benches);

--- a/benches/fill_rect_latched.rs
+++ b/benches/fill_rect_latched.rs
@@ -135,7 +135,7 @@ fn fill_rect_benchmark(c: &mut Criterion) {
                 let mut fb = TestFrameBuffer::new();
                 b.iter(|| {
                     for _ in 0..*iterations {
-                        fb.clear();
+                        fb.erase();
                         black_box(draw_rect_baseline(
                             black_box(&mut fb),
                             black_box(rect),
@@ -154,7 +154,7 @@ fn fill_rect_benchmark(c: &mut Criterion) {
                 let mut fb = TestFrameBuffer::new();
                 b.iter(|| {
                     for _ in 0..*iterations {
-                        fb.clear();
+                        fb.erase();
                         black_box(draw_rect_optimized(
                             black_box(&mut fb),
                             black_box(rect),

--- a/benches/fill_rect_plain.rs
+++ b/benches/fill_rect_plain.rs
@@ -135,7 +135,7 @@ fn fill_rect_benchmark(c: &mut Criterion) {
                 let mut fb = TestFrameBuffer::new();
                 b.iter(|| {
                     for _ in 0..*iterations {
-                        fb.clear();
+                        fb.erase();
                         black_box(draw_rect_baseline(
                             black_box(&mut fb),
                             black_box(rect),
@@ -154,7 +154,7 @@ fn fill_rect_benchmark(c: &mut Criterion) {
                 let mut fb = TestFrameBuffer::new();
                 b.iter(|| {
                     for _ in 0..*iterations {
-                        fb.clear();
+                        fb.erase();
                         black_box(draw_rect_optimized(
                             black_box(&mut fb),
                             black_box(rect),

--- a/benches/render_text_latched.rs
+++ b/benches/render_text_latched.rs
@@ -94,7 +94,7 @@ fn render_text_benchmark(c: &mut Criterion) {
                 b.iter(|| {
                     let mut fb = TestFrameBuffer::new();
                     for _ in 0..iterations {
-                        fb.clear();
+                        fb.erase();
                         black_box(draw_text_baseline(
                             black_box(&mut fb),
                             black_box(origin),
@@ -115,7 +115,7 @@ fn render_text_benchmark(c: &mut Criterion) {
                 b.iter(|| {
                     let mut fb = TestFrameBuffer::new();
                     for _ in 0..iterations {
-                        fb.clear();
+                        fb.erase();
                         black_box(draw_text_optimised(
                             black_box(&mut fb),
                             black_box(origin),

--- a/benches/render_text_plain.rs
+++ b/benches/render_text_plain.rs
@@ -94,7 +94,7 @@ fn render_text_benchmark(c: &mut Criterion) {
                 b.iter(|| {
                     let mut fb = TestFrameBuffer::new();
                     for _ in 0..iterations {
-                        fb.clear();
+                        fb.erase();
                         black_box(draw_text_baseline(
                             black_box(&mut fb),
                             black_box(origin),
@@ -115,7 +115,7 @@ fn render_text_benchmark(c: &mut Criterion) {
                 b.iter(|| {
                     let mut fb = TestFrameBuffer::new();
                     for _ in 0..iterations {
-                        fb.clear();
+                        fb.erase();
                         black_box(draw_text_optimised(
                             black_box(&mut fb),
                             black_box(origin),

--- a/benches/set_pixel_latched.rs
+++ b/benches/set_pixel_latched.rs
@@ -31,7 +31,6 @@ fn set_pixel_latched(c: &mut Criterion) {
 
     group.bench_function("latched_dma_framebuffer", |b| {
         let mut fb = DmaFrameBuffer::<ROWS, COLS, NROWS, BITS, FRAME_COUNT>::new();
-        fb.clear();
 
         b.iter(|| {
             for _ in 0..ITERATIONS {

--- a/benches/set_pixel_plain.rs
+++ b/benches/set_pixel_plain.rs
@@ -31,7 +31,6 @@ fn set_pixel_plain(c: &mut Criterion) {
 
     group.bench_function("plain_dma_framebuffer", |b| {
         let mut fb = DmaFrameBuffer::<ROWS, COLS, NROWS, BITS, FRAME_COUNT>::new();
-        fb.clear();
 
         b.iter(|| {
             for _ in 0..ITERATIONS {

--- a/src/latched.rs
+++ b/src/latched.rs
@@ -79,9 +79,6 @@ doc = ::embed_doc_image::embed_image!("latch-circuit", "images/latch-circuit.png
 //!
 //! let mut framebuffer = DmaFrameBuffer::<ROWS, COLS, NROWS, BITS, FRAME_COUNT>::new();
 //!
-//! // Clear the framebuffer
-//! framebuffer.clear();
-//!
 //! // Draw a red rectangle
 //! Rectangle::new(Point::new(10, 10), Size::new(20, 20))
 //!     .into_styled(PrimitiveStyle::with_fill(Color::RED))
@@ -576,7 +573,7 @@ impl<
         }
     }
 
-    /// Clear pixel colors while preserving control bits.
+    /// Erase pixel colors while preserving control bits.
     /// This is much faster than `format()` and is the typical way to clear the display.
     /// # Example
     /// ```rust,no_run
@@ -590,10 +587,10 @@ impl<
     ///
     /// let mut framebuffer = DmaFrameBuffer::<ROWS, COLS, NROWS, BITS, FRAME_COUNT>::new();
     /// // ... draw some pixels ...
-    /// framebuffer.clear(); // Fast clear of pixel data
+    /// framebuffer.erase();
     /// ```
     #[inline]
-    pub fn clear(&mut self) {
+    pub fn erase(&mut self) {
         for frame in &mut self.frames {
             frame.clear_colors();
         }
@@ -612,7 +609,6 @@ impl<
     /// const FRAME_COUNT: usize = compute_frame_count(BITS); // Number of frames for BCM
     ///
     /// let mut framebuffer = DmaFrameBuffer::<ROWS, COLS, NROWS, BITS, FRAME_COUNT>::new();
-    /// framebuffer.clear();
     /// framebuffer.set_pixel(Point::new(10, 10), Color::RED);
     /// ```
     pub fn set_pixel(&mut self, p: Point, color: Color) {
@@ -1479,7 +1475,6 @@ mod tests {
     #[test]
     fn test_color_values() {
         let mut fb = TestFrameBuffer::new();
-        fb.clear();
 
         // Test different color values
         let colors = [
@@ -1618,7 +1613,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clear() {
+    fn test_erase() {
         let mut fb = TestFrameBuffer::new();
 
         // Set some pixels
@@ -1632,8 +1627,8 @@ mod tests {
         assert_eq!(fb.frames[0].rows[5].data[mapped_col_10].red1(), true);
         assert_eq!(fb.frames[0].rows[10].data[mapped_col_20].grn1(), true);
 
-        // Clear
-        fb.clear();
+        // erase
+        fb.erase();
 
         // Verify pixels are cleared but control bits are preserved
         assert_eq!(fb.frames[0].rows[5].data[mapped_col_10].red1(), false);
@@ -1871,7 +1866,6 @@ mod tests {
         let lower_right = Point::new(TEST_COLS as i32 - CHAR_W, TEST_ROWS as i32 - CHAR_H);
 
         let mut fb = TestFrameBuffer::new();
-        fb.clear();
 
         // Verify glyph in the upper-left corner.
         verify_glyph_at(&mut fb, upper_left);

--- a/src/plain.rs
+++ b/src/plain.rs
@@ -57,9 +57,6 @@
 //!
 //! let mut framebuffer = DmaFrameBuffer::<ROWS, COLS, NROWS, BITS, FRAME_COUNT>::new();
 //!
-//! // Clear the framebuffer
-//! framebuffer.clear();
-//!
 //! // Draw a red rectangle
 //! Rectangle::new(Point::new(10, 10), Size::new(20, 20))
 //!     .into_styled(PrimitiveStyle::with_fill(Color::RED))
@@ -522,7 +519,7 @@ impl<
         }
     }
 
-    /// Fast clear operation that clears all pixel data while preserving timing signals.
+    /// Fast erase operation that clears all pixel data while preserving timing signals.
     ///
     /// This is much faster than `format()` when you just want to clear the display
     /// since it preserves all the timing and control signals that are already set up.
@@ -539,10 +536,10 @@ impl<
     /// const FRAME_COUNT: usize = compute_frame_count(BITS); // Number of frames for BCM
     ///
     /// let mut framebuffer = DmaFrameBuffer::<ROWS, COLS, NROWS, BITS, FRAME_COUNT>::new();
-    /// framebuffer.clear(); // Fast clear for new content
+    /// framebuffer.erase();
     /// ```
     #[inline]
-    pub fn clear(&mut self) {
+    pub fn erase(&mut self) {
         for frame in &mut self.frames {
             frame.clear_colors();
         }
@@ -561,7 +558,6 @@ impl<
     /// const FRAME_COUNT: usize = compute_frame_count(BITS); // Number of frames for BCM
     ///
     /// let mut framebuffer = DmaFrameBuffer::<ROWS, COLS, NROWS, BITS, FRAME_COUNT>::new();
-    /// framebuffer.clear();
     /// framebuffer.set_pixel(Point::new(10, 10), Color::RED);
     /// ```
     pub fn set_pixel(&mut self, p: Point, color: Color) {
@@ -1120,10 +1116,10 @@ mod tests {
     }
 
     #[test]
-    fn test_dma_framebuffer_clear() {
+    fn test_dma_framebuffer_erase() {
         let fb = TestFrameBuffer::new();
 
-        // After clearing, all frames should be formatted
+        // After erasing, all frames should be formatted
         for frame in &fb.frames {
             for addr in 0..TEST_NROWS {
                 let prev_addr = if addr == 0 { TEST_NROWS - 1 } else { addr - 1 };
@@ -1678,7 +1674,7 @@ mod tests {
         assert_eq!(fb.frames[0].rows[5].data[mapped_col_10].red1(), true);
 
         // Clear using fast method
-        fb.clear();
+        fb.erase();
 
         // Verify pixels are cleared but timing signals remain
         assert_eq!(fb.frames[0].rows[5].data[mapped_col_10].red1(), false);
@@ -1759,7 +1755,6 @@ mod tests {
         let lower_right = Point::new(TEST_COLS as i32 - CHAR_W, TEST_ROWS as i32 - CHAR_H);
 
         let mut fb = TestFrameBuffer::new();
-        fb.clear();
 
         verify_glyph_at(&mut fb, upper_left);
         verify_glyph_at(&mut fb, lower_right);


### PR DESCRIPTION
BREAKING CHANGE: DmaFrameBuffer::clear() is now DmaFrameBuffer::erase().