### PR TITLE
Implemented tiling framebuffer wrapper

### DIFF
--- a/src/latched.rs
+++ b/src/latched.rs
@@ -178,6 +178,7 @@ use embedded_dma::ReadBuffer;
 use embedded_graphics::pixelcolor::Rgb888;
 use embedded_graphics::pixelcolor::RgbColor;
 use embedded_graphics::prelude::Point;
+use crate::FrameBufferUser;
 #[cfg(feature = "esp-hal-dma")]
 use esp_hal::dma::ReadBuffer;
 
@@ -652,6 +653,30 @@ impl<
                 frame_idx < blue_frames,
             );
         }
+    }
+}
+
+impl<
+        const ROWS: usize,
+        const COLS: usize,
+        const NROWS: usize,
+        const BITS: u8,
+        const FRAME_COUNT: usize,
+    > FrameBufferUser<ROWS, COLS, NROWS, BITS, FRAME_COUNT> for DmaFrameBuffer<ROWS, COLS, NROWS, BITS, FRAME_COUNT>
+{
+    #[inline]
+    fn erase(&mut self) {
+        self.erase();
+    }
+
+    #[inline]
+    fn format(&mut self) {
+        self.format();
+    }
+
+    #[inline]
+    fn set_pixel(&mut self, p: Point, color: Color) {
+        self.set_pixel(p, color);
     }
 }
 
@@ -1800,7 +1825,7 @@ mod tests {
     const CHAR_W: i32 = 6;
     const CHAR_H: i32 = 10;
 
-    /// Draws the glyph 'A' at `origin` and verifies every pixel against a software reference.  
+    /// Draws the glyph 'A' at `origin` and verifies every pixel against a software reference.
     /// Re-usable for different panel locations.
     fn verify_glyph_at(fb: &mut TestFrameBuffer, origin: Point) {
         use embedded_graphics::mock_display::MockDisplay;

--- a/src/latched.rs
+++ b/src/latched.rs
@@ -172,7 +172,7 @@ doc = ::embed_doc_image::embed_image!("latch-circuit", "images/latch-circuit.png
 use core::convert::Infallible;
 
 use super::Color;
-use crate::FrameBufferUser;
+use crate::FrameBufferOperations;
 use bitfield::bitfield;
 #[cfg(not(feature = "esp-hal-dma"))]
 use embedded_dma::ReadBuffer;
@@ -662,22 +662,17 @@ impl<
         const NROWS: usize,
         const BITS: u8,
         const FRAME_COUNT: usize,
-    > FrameBufferUser<ROWS, COLS, NROWS, BITS, FRAME_COUNT>
+    > FrameBufferOperations<ROWS, COLS, NROWS, BITS, FRAME_COUNT>
     for DmaFrameBuffer<ROWS, COLS, NROWS, BITS, FRAME_COUNT>
 {
     #[inline]
     fn erase(&mut self) {
-        self.erase();
-    }
-
-    #[inline]
-    fn format(&mut self) {
-        self.format();
+        DmaFrameBuffer::<ROWS, COLS, NROWS, BITS, FRAME_COUNT>::erase(self);
     }
 
     #[inline]
     fn set_pixel(&mut self, p: Point, color: Color) {
-        self.set_pixel(p, color);
+        DmaFrameBuffer::<ROWS, COLS, NROWS, BITS, FRAME_COUNT>::set_pixel(self, p, color);
     }
 }
 

--- a/src/latched.rs
+++ b/src/latched.rs
@@ -172,13 +172,13 @@ doc = ::embed_doc_image::embed_image!("latch-circuit", "images/latch-circuit.png
 use core::convert::Infallible;
 
 use super::Color;
+use crate::FrameBufferUser;
 use bitfield::bitfield;
 #[cfg(not(feature = "esp-hal-dma"))]
 use embedded_dma::ReadBuffer;
 use embedded_graphics::pixelcolor::Rgb888;
 use embedded_graphics::pixelcolor::RgbColor;
 use embedded_graphics::prelude::Point;
-use crate::FrameBufferUser;
 #[cfg(feature = "esp-hal-dma")]
 use esp_hal::dma::ReadBuffer;
 
@@ -662,7 +662,8 @@ impl<
         const NROWS: usize,
         const BITS: u8,
         const FRAME_COUNT: usize,
-    > FrameBufferUser<ROWS, COLS, NROWS, BITS, FRAME_COUNT> for DmaFrameBuffer<ROWS, COLS, NROWS, BITS, FRAME_COUNT>
+    > FrameBufferUser<ROWS, COLS, NROWS, BITS, FRAME_COUNT>
+    for DmaFrameBuffer<ROWS, COLS, NROWS, BITS, FRAME_COUNT>
 {
     #[inline]
     fn erase(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,7 @@ pub trait MutableFrameBuffer<
 /// * `NROWS` - Number of rows processed in parallel
 /// * `BITS` - Number of bits per color channel
 /// * `FRAME_COUNT` - Number of frames needed for BCM
-pub trait FrameBufferUser<
+pub trait FrameBufferOperations<
     const ROWS: usize,
     const COLS: usize,
     const NROWS: usize,
@@ -223,11 +223,6 @@ pub trait FrameBufferUser<
     const FRAME_COUNT: usize,
 >: FrameBuffer<ROWS, COLS, NROWS, BITS, FRAME_COUNT>
 {
-    /// Format the framebuffer, setting up all control bits and clearing pixel data.
-    /// This method does a full format of all control bits and clears all pixel data.
-    /// Normally you don't need to call this as `new()` automatically formats the framebuffer.
-    fn format(&mut self);
-
     /// Erase pixel colors while preserving control bits.
     /// This is much faster than `format()` and is the typical way to clear the display.
     fn erase(&mut self);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,8 +221,8 @@ pub trait FrameBufferUser<
     const NROWS: usize,
     const BITS: u8,
     const FRAME_COUNT: usize,
->: FrameBuffer<ROWS, COLS, NROWS, BITS, FRAME_COUNT>{
-
+>: FrameBuffer<ROWS, COLS, NROWS, BITS, FRAME_COUNT>
+{
     /// Format the framebuffer, setting up all control bits and clearing pixel data.
     /// This method does a full format of all control bits and clears all pixel data.
     /// Normally you don't need to call this as `new()` automatically formats the framebuffer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@
 use embedded_dma::ReadBuffer;
 use embedded_graphics::draw_target::DrawTarget;
 use embedded_graphics::pixelcolor::Rgb888;
+use embedded_graphics::prelude::Point;
 #[cfg(feature = "esp-hal-dma")]
 use esp_hal::dma::ReadBuffer;
 
@@ -203,6 +204,36 @@ pub trait MutableFrameBuffer<
     FrameBuffer<ROWS, COLS, NROWS, BITS, FRAME_COUNT>
     + DrawTarget<Color = Color, Error = core::convert::Infallible>
 {
+}
+
+/// Trait for all operations a user may want to call on a framebuffer.
+///
+/// # Type Parameters
+///
+/// * `ROWS` - Total number of rows in the display
+/// * `COLS` - Number of columns in the display
+/// * `NROWS` - Number of rows processed in parallel
+/// * `BITS` - Number of bits per color channel
+/// * `FRAME_COUNT` - Number of frames needed for BCM
+pub trait FrameBufferUser<
+    const ROWS: usize,
+    const COLS: usize,
+    const NROWS: usize,
+    const BITS: u8,
+    const FRAME_COUNT: usize,
+>: FrameBuffer<ROWS, COLS, NROWS, BITS, FRAME_COUNT>{
+
+    /// Format the framebuffer, setting up all control bits and clearing pixel data.
+    /// This method does a full format of all control bits and clears all pixel data.
+    /// Normally you don't need to call this as `new()` automatically formats the framebuffer.
+    fn format(&mut self);
+
+    /// Erase pixel colors while preserving control bits.
+    /// This is much faster than `format()` and is the typical way to clear the display.
+    fn erase(&mut self);
+
+    /// Set a pixel in the framebuffer.
+    fn set_pixel(&mut self, p: Point, color: Color);
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ use esp_hal::dma::ReadBuffer;
 
 pub mod latched;
 pub mod plain;
+pub mod tiling;
 
 /// Color type used in the framebuffer
 pub type Color = Rgb888;

--- a/src/plain.rs
+++ b/src/plain.rs
@@ -131,12 +131,12 @@
 
 use core::convert::Infallible;
 
+use crate::FrameBufferUser;
 use bitfield::bitfield;
 #[cfg(not(feature = "esp-hal-dma"))]
 use embedded_dma::ReadBuffer;
 use embedded_graphics::pixelcolor::RgbColor;
 use embedded_graphics::prelude::Point;
-use crate::FrameBufferUser;
 #[cfg(feature = "esp-hal-dma")]
 use esp_hal::dma::ReadBuffer;
 
@@ -611,7 +611,8 @@ impl<
         const NROWS: usize,
         const BITS: u8,
         const FRAME_COUNT: usize,
-    > FrameBufferUser<ROWS, COLS, NROWS, BITS, FRAME_COUNT> for DmaFrameBuffer<ROWS, COLS, NROWS, BITS, FRAME_COUNT>
+    > FrameBufferUser<ROWS, COLS, NROWS, BITS, FRAME_COUNT>
+    for DmaFrameBuffer<ROWS, COLS, NROWS, BITS, FRAME_COUNT>
 {
     #[inline]
     fn erase(&mut self) {

--- a/src/plain.rs
+++ b/src/plain.rs
@@ -131,7 +131,7 @@
 
 use core::convert::Infallible;
 
-use crate::FrameBufferUser;
+use crate::FrameBufferOperations;
 use bitfield::bitfield;
 #[cfg(not(feature = "esp-hal-dma"))]
 use embedded_dma::ReadBuffer;
@@ -611,22 +611,17 @@ impl<
         const NROWS: usize,
         const BITS: u8,
         const FRAME_COUNT: usize,
-    > FrameBufferUser<ROWS, COLS, NROWS, BITS, FRAME_COUNT>
+    > FrameBufferOperations<ROWS, COLS, NROWS, BITS, FRAME_COUNT>
     for DmaFrameBuffer<ROWS, COLS, NROWS, BITS, FRAME_COUNT>
 {
     #[inline]
     fn erase(&mut self) {
-        self.erase();
-    }
-
-    #[inline]
-    fn format(&mut self) {
-        self.format();
+        DmaFrameBuffer::<ROWS, COLS, NROWS, BITS, FRAME_COUNT>::erase(self);
     }
 
     #[inline]
     fn set_pixel(&mut self, p: Point, color: Color) {
-        self.set_pixel(p, color);
+        DmaFrameBuffer::<ROWS, COLS, NROWS, BITS, FRAME_COUNT>::set_pixel(self, p, color);
     }
 }
 

--- a/src/plain.rs
+++ b/src/plain.rs
@@ -136,6 +136,7 @@ use bitfield::bitfield;
 use embedded_dma::ReadBuffer;
 use embedded_graphics::pixelcolor::RgbColor;
 use embedded_graphics::prelude::Point;
+use crate::FrameBufferUser;
 #[cfg(feature = "esp-hal-dma")]
 use esp_hal::dma::ReadBuffer;
 
@@ -601,6 +602,30 @@ impl<
                 frame_idx < blue_frames,
             );
         }
+    }
+}
+
+impl<
+        const ROWS: usize,
+        const COLS: usize,
+        const NROWS: usize,
+        const BITS: u8,
+        const FRAME_COUNT: usize,
+    > FrameBufferUser<ROWS, COLS, NROWS, BITS, FRAME_COUNT> for DmaFrameBuffer<ROWS, COLS, NROWS, BITS, FRAME_COUNT>
+{
+    #[inline]
+    fn erase(&mut self) {
+        self.erase();
+    }
+
+    #[inline]
+    fn format(&mut self) {
+        self.format();
+    }
+
+    #[inline]
+    fn set_pixel(&mut self, p: Point, color: Color) {
+        self.set_pixel(p, color);
     }
 }
 

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -1,0 +1,353 @@
+//! For tiling multiple displays together in various grid arrangements
+//! They have to be tiles together
+
+use core::convert::Infallible;
+
+use crate::{Color};
+use embedded_graphics::prelude::{PixelColor};
+
+/// Computes the number of columns needed if the displays are bing tiled together.
+/// # Arguments
+///
+/// * `cols` - Number of columns per panel
+/// * `num_panels_wide` - Number of panels tiled horizontally
+/// * `num_panels_high` - Number of panels tiled vertically
+///
+/// # Returns
+///
+/// Number of columns needed internally for `DmaFrameBuffer`
+pub const fn compute_tiled_cols(cols: usize, num_panels_wide: usize, num_panels_high: usize) -> usize {
+    cols * num_panels_wide * num_panels_high
+}
+
+/// Trait for pixel remappers
+///
+/// Implementors of this trait will remap x,y coordinates from a
+/// virtual panel to the actual framebuffer used to drive the panels
+///
+/// # Type Parameters
+///
+/// * `PANEL_ROWS` - Number of rows in a single panel
+/// * `PANEL_COLS` - Number of columns in a single panel
+/// * `TILE_ROWS` - Number of panels stacked vertically
+/// * `TILE_COLS` - Number of panels stacked horizontally
+pub trait PixelRemapper<
+    const PANEL_ROWS: usize,
+    const PANEL_COLS: usize,
+    const TILE_ROWS: usize,
+    const TILE_COLS: usize,
+>
+{
+    /// Number of rows in the virtual panel
+    const VIRT_ROWS: usize = PANEL_ROWS * TILE_ROWS;
+    /// Number of columns in the virtual panel
+    const VIRT_COLS: usize = PANEL_COLS * TILE_COLS;
+    /// Number of rows in the actual framebuffer
+    const FB_ROWS: usize = PANEL_ROWS;
+    /// Number of columns in the actual framebuffer
+    const FB_COLS: usize = PANEL_COLS * TILE_COLS * TILE_ROWS;
+
+    /// Remap a virtual pixel to a framebuffer pixel
+    fn remap<C: PixelColor>(pixel: embedded_graphics::Pixel<C>) -> embedded_graphics::Pixel<C>;
+
+    /// Size of the virtual panel
+    #[inline]
+    fn virtual_size() -> (usize, usize) {
+        (Self::VIRT_ROWS, Self::VIRT_COLS)
+    }
+
+    /// Size of the framebuffer that this remaps to
+    #[inline]
+    fn fb_size() -> (usize, usize) {
+        (Self::FB_ROWS, Self::FB_COLS)
+    }
+}
+
+/// Chaining strategy for tiled panels
+///
+/// This type should be provided to the [TiledFrameBuffer] as a type argument.
+/// Take a look at its documentation for more details
+///
+/// When looking at the front, panels are chained together starting at the top right, chaining to the
+/// left until the end of the column. Then wrapping down to the next row where panels are chained left to right.
+/// This makes every second rows panels installed upside down.
+/// This pattern repeats until all rows of panels are covered.
+///
+/// # Type Parameters
+///
+/// * `PANEL_ROWS` - Number of rows in a single panel
+/// * `PANEL_COLS` - Number of columns in a single panel
+/// * `TILE_ROWS` - Number of panels stacked vertically
+/// * `TILE_COLS` - Number of panels stacked horizontally
+pub struct ChainTopRightDown<
+    const PANEL_ROWS: usize,
+    const PANEL_COLS: usize,
+    const TILE_ROWS: usize,
+    const TILE_COLS: usize,
+> {}
+
+impl<
+        const PANEL_ROWS: usize,
+        const PANEL_COLS: usize,
+        const TILE_ROWS: usize,
+        const TILE_COLS: usize,
+    > ChainTopRightDown<PANEL_ROWS, PANEL_COLS, TILE_ROWS, TILE_COLS>
+{
+    /// Create a new panel chain
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl<
+        const PANEL_ROWS: usize,
+        const PANEL_COLS: usize,
+        const TILE_ROWS: usize,
+        const TILE_COLS: usize,
+    > PixelRemapper<PANEL_ROWS, PANEL_COLS, TILE_ROWS, TILE_COLS>
+    for ChainTopRightDown<PANEL_ROWS, PANEL_COLS, TILE_ROWS, TILE_COLS>
+{
+    fn remap<C: PixelColor>(mut pixel: embedded_graphics::Pixel<C>) -> embedded_graphics::Pixel<C> {
+        let row = TILE_ROWS as i32 -  pixel.0.y / PANEL_ROWS as i32 - 1;
+        if row % 2 == 1 {
+            // panel is upside down
+            pixel.0.x = Self::FB_COLS as i32 - pixel.0.x - (row * Self::VIRT_COLS as i32) - 1;
+            pixel.0.y = PANEL_ROWS as i32 - 1 - (pixel.0.y % PANEL_ROWS as i32);
+        } else {
+            pixel.0.x = (row * Self::VIRT_COLS as i32) + pixel.0.x;
+            pixel.0.y = pixel.0.y % PANEL_ROWS as i32;
+        }
+        pixel
+    }
+}
+
+/// Tile together multiple displays in a certain configuration to form a single larger display
+///
+/// This is a wrapper around an actual framebuffer implementation which can be used to tile multiple
+/// LED matrices together by using a certain pixel remapping strategy.
+/// # Example
+/// ```rust
+/// use hub75_framebuffer::compute_frame_count;
+/// use hub75_framebuffer::compute_rows;
+/// use hub75_framebuffer::plain::DmaFrameBuffer;
+/// use hub75_framebuffer::tiling::{TiledFrameBuffer, ChainTopRightDown};
+///
+/// const TILED_COLS: usize = 3;
+/// const TILED_ROWS: usize = 3;
+/// const ROWS: usize = 32;
+/// const PANEL_COLS: usize = 64;
+/// const COLS: usize = PANEL_COLS * TILED_ROWS * TILED_COLS;
+/// const BITS: u8 = 4;
+/// const NROWS: usize = compute_rows(ROWS);
+/// const FRAME_COUNT: usize = compute_frame_count(BITS);
+///
+/// type FBType = DmaFrameBuffer<ROWS, COLS, NROWS, BITS, FRAME_COUNT>;
+/// type PanelChain = ChainTopRightDown<ROWS, PANEL_COLS, TILED_ROWS, TILED_COLS>;
+///
+/// let mut fb = FBType::new();
+/// let mut fb = TiledFrameBuffer::new(&mut fb, PanelChain::new());
+///
+/// // Now fb is ready to be used and can be treated like one big canvas (192*96 pixels in this example)
+/// // The tiles framebuffer does intentionally not reimplement any functions of the underlying framebuffer
+/// // If you need to access them you may use `fb.0`
+/// ```
+pub struct TiledFrameBuffer<'a,
+    F,
+    M,
+    const PANEL_ROWS: usize,
+    const PANEL_COLS: usize,
+    const TILE_ROWS: usize,
+    const TILE_COLS: usize,
+>(pub &'a mut F, M);
+
+impl<'a,
+        F,
+        M,
+        const PANEL_ROWS: usize,
+        const PANEL_COLS: usize,
+        const TILE_ROWS: usize,
+        const TILE_COLS: usize,
+    > TiledFrameBuffer<'a, F, M, PANEL_ROWS, PANEL_COLS, TILE_ROWS, TILE_COLS>
+where
+    F: embedded_graphics::draw_target::DrawTarget,
+    M: PixelRemapper<PANEL_ROWS, PANEL_COLS, TILE_ROWS, TILE_COLS>,
+{
+    /// Create a new "virtual display" that takes ownership of the underlying framebuffer
+    /// an remaps any pixels written to it to the correct locations of the underlying framebuffer
+    /// based on the given PixelRemapper
+    pub fn new(fb: &'a mut F, mapper: M) -> Self {
+        Self(fb, mapper)
+    }
+}
+
+impl<'a,
+        F,
+        M,
+        const PANEL_ROWS: usize,
+        const PANEL_COLS: usize,
+        const TILE_ROWS: usize,
+        const TILE_COLS: usize,
+    > embedded_graphics::draw_target::DrawTarget
+    for TiledFrameBuffer<'a, F, M, PANEL_ROWS, PANEL_COLS, TILE_ROWS, TILE_COLS>
+where
+    F: embedded_graphics::draw_target::DrawTarget<Color = Color, Error = Infallible>,
+    M: PixelRemapper<PANEL_ROWS, PANEL_COLS, TILE_ROWS, TILE_COLS>,
+{
+    type Color = Color;
+    type Error = Infallible;
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = embedded_graphics::Pixel<Self::Color>>,
+    {
+        self.0.draw_iter(pixels.into_iter().map(M::remap))
+    }
+}
+
+impl<'a,
+        F,
+        M,
+        const PANEL_ROWS: usize,
+        const PANEL_COLS: usize,
+        const TILE_ROWS: usize,
+        const TILE_COLS: usize,
+    > embedded_graphics::prelude::OriginDimensions
+    for TiledFrameBuffer<'a, F, M, PANEL_ROWS, PANEL_COLS, TILE_ROWS, TILE_COLS>
+where
+    M: PixelRemapper<PANEL_ROWS, PANEL_COLS, TILE_ROWS, TILE_COLS>,
+{
+    fn size(&self) -> embedded_graphics::prelude::Size {
+        embedded_graphics::prelude::Size::new(
+            M::virtual_size().1 as u32,
+            M::virtual_size().0 as u32,
+        )
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use embedded_graphics::prelude::*;
+
+    use super::*;
+
+    #[test]
+    fn test_virtual_size_function_with_equal_rows_and_cols() {
+        const ROWS_IN_PANEL: usize = 32;
+        const COLS_IN_PANEL: usize = 64;
+        type PanelChain = ChainTopRightDown<ROWS_IN_PANEL, COLS_IN_PANEL, 3, 3>;
+        let virt_size = PanelChain::virtual_size();
+        assert_eq!(virt_size, (ROWS_IN_PANEL*3, COLS_IN_PANEL*3));
+    }
+
+    #[test]
+    fn test_virtual_size_function_with_uneven_rows_and_cols() {
+        const ROWS_IN_PANEL: usize = 32;
+        const COLS_IN_PANEL: usize = 64;
+        type PanelChain = ChainTopRightDown<ROWS_IN_PANEL, COLS_IN_PANEL, 5, 3>;
+        let virt_size = PanelChain::virtual_size();
+        assert_eq!(virt_size, (ROWS_IN_PANEL*5, COLS_IN_PANEL*3));
+    }
+
+    #[test]
+    fn test_virtual_size_function_with_single_column() {
+        const ROWS_IN_PANEL: usize = 32;
+        const COLS_IN_PANEL: usize = 64;
+        type PanelChain = ChainTopRightDown<ROWS_IN_PANEL, COLS_IN_PANEL, 3, 1>;
+        let virt_size = PanelChain::virtual_size();
+        assert_eq!(virt_size, (ROWS_IN_PANEL*3, COLS_IN_PANEL));
+    }
+
+    #[test]
+    fn test_fb_size_function_with_equal_rows_and_cols() {
+        const ROWS_IN_PANEL: usize = 32;
+        const COLS_IN_PANEL: usize = 64;
+        type PanelChain = ChainTopRightDown<ROWS_IN_PANEL, COLS_IN_PANEL, 3, 3>;
+        let virt_size = PanelChain::fb_size();
+        assert_eq!(virt_size, (ROWS_IN_PANEL, COLS_IN_PANEL*9));
+    }
+
+    #[test]
+    fn test_fb_size_function_with_uneven_rows_and_cols() {
+        const ROWS_IN_PANEL: usize = 32;
+        const COLS_IN_PANEL: usize = 64;
+        type PanelChain = ChainTopRightDown<ROWS_IN_PANEL, COLS_IN_PANEL, 5, 3>;
+        let virt_size = PanelChain::fb_size();
+        assert_eq!(virt_size, (ROWS_IN_PANEL, COLS_IN_PANEL*15));
+    }
+
+    #[test]
+    fn test_fb_size_function_with_single_column() {
+        const ROWS_IN_PANEL: usize = 32;
+        const COLS_IN_PANEL: usize = 64;
+        type PanelChain = ChainTopRightDown<ROWS_IN_PANEL, COLS_IN_PANEL, 3, 1>;
+        let virt_size = PanelChain::fb_size();
+        assert_eq!(virt_size, (ROWS_IN_PANEL, COLS_IN_PANEL*3));
+    }
+
+    #[test]
+    fn test_pixel_remap_top_right_down_point_in_origin() {
+        type PanelChain = ChainTopRightDown<32, 64, 3, 3>;
+
+        let pixel = PanelChain::remap(Pixel(Point::new(0, 0), Color::RED));
+        assert_eq!(pixel.0, Point::new(384, 0));
+    }
+
+    #[test]
+    fn test_pixel_remap_top_right_down_point_in_bottom_left_corner() {
+        type PanelChain = ChainTopRightDown<32, 64, 3, 3>;
+
+        let pixel = PanelChain::remap(Pixel(Point::new(0, 95), Color::RED));
+        assert_eq!(pixel.0, Point::new(0, 31));
+    }
+
+    #[test]
+    fn test_pixel_remap_top_right_down_point_in_bottom_right_corner() {
+        type PanelChain = ChainTopRightDown<32, 64, 3, 3>;
+
+        let pixel = PanelChain::remap(Pixel(Point::new(191, 95), Color::RED));
+        assert_eq!(pixel.0, Point::new(191, 31));
+    }
+
+    #[test]
+    fn test_pixel_remap_top_right_down_point_on_x_right_edge_of_first_panel() {
+        type PanelChain = ChainTopRightDown<32, 64, 3, 3>;
+
+        let pixel = PanelChain::remap(Pixel(Point::new(63, 0), Color::RED));
+        assert_eq!(pixel.0, Point::new(447, 0));
+    }
+
+    #[test]
+    fn test_pixel_remap_top_right_down_point_on_x_left_edge_of_second_panel() {
+        type PanelChain = ChainTopRightDown<32, 64, 3, 3>;
+
+        let pixel = PanelChain::remap(Pixel(Point::new(64, 0), Color::RED));
+        assert_eq!(pixel.0, Point::new(448, 0));
+    }
+
+    #[test]
+    fn test_pixel_remap_top_right_down_point_on_y_bottom_edge_of_first_panel() {
+        type PanelChain = ChainTopRightDown<32, 64, 3, 3>;
+
+        let pixel = PanelChain::remap(Pixel(Point::new(0, 31), Color::RED));
+        assert_eq!(pixel.0, Point::new(384, 31));
+    }
+
+    #[test]
+    fn test_pixel_remap_top_right_down_point_on_y_top_edge_of_fourth_panel() {
+        type PanelChain = ChainTopRightDown<32, 64, 3, 3>;
+
+        let pixel = PanelChain::remap(Pixel(Point::new(0, 32), Color::RED));
+        assert_eq!(pixel.0, Point::new(383, 31));
+    }
+
+    #[test]
+    fn test_pixel_remap_top_right_down_point_slightly_to_the_top_middle() {
+        type PanelChain = ChainTopRightDown<32, 64, 3, 3>;
+
+        let pixel = PanelChain::remap(Pixel(Point::new(100, 40), Color::RED));
+        assert_eq!(pixel.0, Point::new(283, 23));
+    }
+}


### PR DESCRIPTION
This implements support for chaining multiple displays together in a tiled configuration.
This PR adds the new `TiledFrameBuffer` mentioned in [#23](https://github.com/liebman/esp-hub75/issues/23)

## Implementation details

It is implemented as a wrapper which can use any of the other framebuffer types underneath.

I tried to keep the existing API completely untouched, but I had to add the new `FrameBufferUser` trait which is now implemented by both FB implementations such that both types can be used by the `TilingFrameBuffer`.
But still no user of this crate should need to change their code with the current way this is implemented.

## Open points

I personally am not a big fan of how  convoluted the type definition of the `TilingFrameBuffer` has become. Mostly because a user will need to pass the same const type arguments to 3 different types now. But I also found no better way of handling this right now. I would be happy about any improvement suggestions.
The only possible solution which comes to my mind is to handle the type definition via a macro. If this is desired I can add an implementation of such a macro to the PR.

Any improvement suggestions are welcome!

## Known issues

None.
I tested this with some of the examples from the esp_hub75 repo and I have found no issues so far.



## Example

Here is some example code which adapts the dimming example:

```rust
#![no_std]
#![no_main]
#![deny(
    clippy::mem_forget,
    reason = "mem::forget is generally not safe to do with esp_hal types, especially those \
    holding buffers for the duration of a data transfer."
)]
#![feature(type_alias_impl_trait)]

use alloc::fmt;
use embassy_executor::{task, Spawner};
use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
use embassy_sync::signal::Signal;
use embassy_time::Instant;
use embassy_time::{Duration, Timer};
use embedded_graphics::mono_font::ascii::FONT_5X7;
use embedded_graphics::prelude::*;
use esp_backtrace as _;
use esp_hal::clock::CpuClock;
use esp_hal::interrupt::software::SoftwareInterruptControl;
use esp_hal::interrupt::Priority;
use esp_hal::timer::systimer::SystemTimer;
use esp_hal_embassy::InterruptExecutor;
use heapless::String;
use log::info;

use embedded_graphics::geometry::Point;
use embedded_graphics::mono_font::MonoTextStyleBuilder;
use embedded_graphics::prelude::RgbColor;
use embedded_graphics::text::Alignment;
use embedded_graphics::text::Text;
use embedded_graphics::Drawable;
use esp_hal::gpio::Pin;
use esp_hal::peripherals::LCD_CAM;
use esp_hal::time::Rate;
use esp_hub75::framebuffer::compute_frame_count;
use esp_hub75::framebuffer::compute_rows;
use esp_hub75::framebuffer::plain::DmaFrameBuffer;
use esp_hub75::Color;
use esp_hub75::Hub75;
use esp_hub75::Hub75Pins16;
use hub75_framebuffer::tiling::{compute_tiled_cols, ChainTopRightDown, TiledFrameBuffer};

use core::sync::atomic::{AtomicU32, AtomicU8, Ordering};
use static_cell::make_static;

extern crate alloc;

// This creates a default app-descriptor required by the esp-idf bootloader.
// For more information see: <https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/app_image_format.html#application-description>
esp_bootloader_esp_idf::esp_app_desc!();

const TILED_COLS: usize = 3;
const TILED_ROWS: usize = 3;
const ROWS: usize = 32;
const PANEL_COLS: usize = 64;
const FB_COLS: usize = compute_tiled_cols(PANEL_COLS, TILED_ROWS, TILED_COLS);
const BITS: u8 = 2;
const NROWS: usize = compute_rows(ROWS);
const FRAME_COUNT: usize = compute_frame_count(BITS);

static REFRESH_RATE: AtomicU32 = AtomicU32::new(0);
static RENDER_RATE: AtomicU32 = AtomicU32::new(0);
static BRIGHTNESS: AtomicU8 = AtomicU8::new(128);

type FBType = DmaFrameBuffer<ROWS, FB_COLS, NROWS, BITS, FRAME_COUNT>;
type TiledFBType = TiledFrameBuffer<
    FBType,
    ChainTopRightDown<ROWS, PANEL_COLS, TILED_ROWS, TILED_COLS>,
    ROWS,
    PANEL_COLS,
    NROWS,
    BITS,
    FRAME_COUNT,
    TILED_ROWS,
    TILED_COLS,
    FB_COLS,
>;

type FrameBufferExchange = Signal<CriticalSectionRawMutex, &'static mut TiledFBType>;

pub struct Hub75Peripherals<'d> {
    pub lcd_cam: LCD_CAM<'d>,
    pub dma_channel: esp_hal::peripherals::DMA_CH0<'d>,
    pub pins: Hub75Pins16<'d>,
}

#[task]
async fn hub75_task(
    peripherals: Hub75Peripherals<'static>,
    rx: &'static FrameBufferExchange,
    tx: &'static FrameBufferExchange,
    fb: &'static mut TiledFBType,
) {
    info!("hub75_task: starting!");

    let (_, tx_descriptors) = esp_hal::dma_descriptors!(0, FBType::dma_buffer_size_bytes());

    let mut hub75 = Hub75::new_async(
        peripherals.lcd_cam,
        peripherals.pins,
        peripherals.dma_channel,
        tx_descriptors,
        Rate::from_mhz(20), // Set to 1Mhz when using PSRAM. This seems to be on the higher end of what it can handle.
    )
    .expect("failed to create Hub75!");

    let mut count = 0u32;
    let mut start = Instant::now();

    let mut fb = fb;

    loop {
        // if there is a new buffer available, get it and send the old one
        if rx.signaled() {
            let new_fb = rx.wait().await;
            tx.signal(fb);
            fb = new_fb;
        }

        let mut xfer = hub75
            .render(fb)
            .map_err(|(e, _hub75)| e)
            .expect("failed to start render!");
        xfer.wait_for_done()
            .await
            .expect("rendering wait_for_done failed!");
        let (result, new_hub75) = xfer.wait();
        hub75 = new_hub75;
        result.expect("transfer failed");

        // Delay control value (0-255)
        // 0 = never render (infinite delay)
        // 1 = maximum delay (15000 microseconds)
        // 255 = no delay (0 microseconds)
        let delay_control = BRIGHTNESS.load(Ordering::Relaxed); // Use global BRIGHTNESS value

        // Calculate delay based on control value
        let delay_micros = if delay_control == 0 {
            // Never render - use a very long delay
            u64::MAX
        } else {
            // Direct mapping: BRIGHTNESS 1-255 -> delay 15000-0 microseconds
            // Formula: delay = (255 - control_value) * 15000 / 254
            // This gives: 1 -> 15000, 255 -> 0
            (255 - delay_control as u64) * 15000 / 254
        };

        // Apply the calculated delay
        Timer::after(Duration::from_micros(delay_micros)).await;

        count += 1;
        const FPS_INTERVAL: Duration = Duration::from_secs(1);
        if start.elapsed() > FPS_INTERVAL {
            REFRESH_RATE.store(count, Ordering::Relaxed);
            count = 0;
            start = Instant::now();
        }
    }
}

#[task]
async fn display_task(
    rx: &'static FrameBufferExchange,
    tx: &'static FrameBufferExchange,
    mut fb: &'static mut TiledFBType,
) {
    info!("display_task: starting!");
    let fps_style = MonoTextStyleBuilder::new()
        .font(&FONT_5X7)
        .text_color(Color::YELLOW)
        .background_color(Color::BLACK)
        .build();
    let mut count = 0u32;

    let mut start = Instant::now();

    loop {
        fb.clear(Color::BLACK).unwrap();

        let mut buffer: String<64> = String::new();

        fmt::write(
            &mut buffer,
            format_args!("Refresh: {:4}", REFRESH_RATE.load(Ordering::Relaxed)),
        )
        .unwrap();
        Text::with_alignment(
            buffer.as_str(),
            Point::new(0, 10),
            fps_style,
            Alignment::Left,
        )
        .draw(fb)
        .unwrap();

        buffer.clear();
        fmt::write(
            &mut buffer,
            format_args!("Render: {:5}", RENDER_RATE.load(Ordering::Relaxed)),
        )
        .unwrap();

        Text::with_alignment(
            buffer.as_str(),
            Point::new(192 / 2, 63 - 8),
            fps_style,
            Alignment::Center,
        )
        .draw(fb)
        .unwrap();

        buffer.clear();
        fmt::write(
            &mut buffer,
            format_args!("Bright: {:5}", BRIGHTNESS.load(Ordering::Relaxed)),
        )
        .unwrap();
        Text::with_alignment(
            buffer.as_str(),
            Point::new(192, 95),
            fps_style,
            Alignment::Right,
        )
        .draw(fb)
        .unwrap();
        // send the frame buffer to be rendered
        tx.signal(fb);

        // get the next frame buffer
        fb = rx.wait().await;

        // count up the rate we are rendering full buffer
        count += 1;
        const FPS_INTERVAL: Duration = Duration::from_secs(1);
        if start.elapsed() > FPS_INTERVAL {
            RENDER_RATE.store(count, Ordering::Relaxed);
            count = 0;
            start = Instant::now();
        }
    }
}

#[esp_hal_embassy::main]
async fn main(_spawner: Spawner) {
    esp_println::logger::init_logger_from_env();

    let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
    let peripherals = esp_hal::init(config);
    let sw_ints = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
    let software_interrupt = sw_ints.software_interrupt2;

    let timer0 = SystemTimer::new(peripherals.SYSTIMER);
    esp_hal_embassy::init(timer0.alarm0);

    info!("Embassy initialized!");

    // LED Panel init
    let pins = Hub75Pins16 {
        red1: peripherals.GPIO42.degrade(),
        grn1: peripherals.GPIO41.degrade(),
        blu1: peripherals.GPIO40.degrade(),
        red2: peripherals.GPIO38.degrade(),
        grn2: peripherals.GPIO39.degrade(),
        blu2: peripherals.GPIO12.degrade(),
        addr0: peripherals.GPIO45.degrade(),
        addr1: peripherals.GPIO21.degrade(),
        addr2: peripherals.GPIO48.degrade(),
        addr3: peripherals.GPIO4.degrade(),
        addr4: peripherals.GPIO5.degrade(),
        blank: peripherals.GPIO14.degrade(),
        clock: peripherals.GPIO2.degrade(),
        latch: peripherals.GPIO47.degrade(),
    };

    let hub75_per = Hub75Peripherals {
        dma_channel: peripherals.DMA_CH0,
        lcd_cam: peripherals.LCD_CAM,
        pins,
    };

    // If the framebuffer is too large to fit in ram, we can allocate it on the
    // heap in PSRAM instead.
    // Allocate the framebuffer to PSRAM without ever putting it on the stack first
    // esp_alloc::psram_allocator!(peripherals.PSRAM, esp_hal::psram);
    // use alloc::alloc::alloc;
    // use alloc::boxed::Box;
    // use core::alloc::Layout;
    // use hub75_framebuffer::FrameBufferUser;

    // let layout = Layout::new::<TiledFBType>();

    // let fb0 = unsafe {
    //     let ptr = alloc(layout) as *mut TiledFBType;
    //     (*ptr).format();
    //     Box::from_raw(ptr)
    // };
    // let fb1 = unsafe {
    //     let ptr = alloc(layout) as *mut TiledFBType;
    //     (*ptr).format();
    //     Box::from_raw(ptr)
    // };

    // let fb0 = Box::leak(fb0);
    // let fb1 = Box::leak(fb1);

    // Allocate the framebuffers in static memory. This assumes that they fit into ram.
    let fb0 = make_static!(TiledFrameBuffer::new());
    let fb1 = make_static!(TiledFrameBuffer::new());

    info!("init framebuffer exchange");
    static TX: FrameBufferExchange = FrameBufferExchange::new();
    static RX: FrameBufferExchange = FrameBufferExchange::new();

    let cpu1_fnctn = {
        move || {
            let hp_executor = make_static!(InterruptExecutor::new(software_interrupt));
            let high_pri_spawner = hp_executor.start(Priority::Priority3);

            // hub75 runs as high priority task
            high_pri_spawner
                .spawn(hub75_task(hub75_per, &RX, &TX, fb1))
                .ok();

            let lp_executor = make_static!(Executor::new());
            // display task runs as low priority task
            lp_executor.run(|spawner| {
                spawner.spawn(display_task(&TX, &RX, fb0)).ok();
            });
        }
    };

    use esp_hal::system::CpuControl;
    use esp_hal::system::Stack;
    use esp_hal_embassy::Executor;
    let cpu_control = CpuControl::new(peripherals.CPU_CTRL);
    const DISPLAY_STACK_SIZE: usize = 8192;
    let app_core_stack: &mut Stack<DISPLAY_STACK_SIZE> = make_static!(Stack::new());
    let mut _cpu_control = cpu_control;

    #[allow(static_mut_refs)]
    let _guard = _cpu_control
        .start_app_core(app_core_stack, cpu1_fnctn)
        .unwrap();

    let mut direction = 1i8;

    loop {
        // Cycle BRIGHTNESS from 1 to 255 and back
        let current_brightness = BRIGHTNESS.load(Ordering::Relaxed);
        let new_brightness = if current_brightness == 1 {
            direction = 1;
            2
        } else if current_brightness == 255 {
            direction = -1;
            254
        } else {
            if direction == 1 {
                current_brightness + 1
            } else {
                current_brightness - 1
            }
        };

        // // Update BRIGHTNESS
        BRIGHTNESS.store(new_brightness, Ordering::Relaxed);

        Timer::after(Duration::from_millis(100)).await;
    }
}
```