### PR TITLE
add blanking delay tuning features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * bitplane/latched: tweak latch timing & clear values after latch closed to prevent address "bleeding" into the first pixels in some cases
 
+### Added
+
+* plain, bitplane/plain: new `blank-delay-1`, `blank-delay-2`, `blank-delay-4`, and `blank-delay-8` features to control extra blanking time around row address changes, preventing ghosting artifacts on panels with slower address-line settling
+
 ## [0.8.0] - 2026-05-01
 
 ### ⚠️ Breaking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,12 @@ esp32-ordering = []
 defmt = ["dep:defmt"]
 doc-images = ["dep:embed-doc-image"]
 
+# these are for the plain framebuffer only
+blank-delay-1 = []
+blank-delay-2 = []
+blank-delay-4 = []
+blank-delay-8 = []
+
 [dev-dependencies]
 criterion = "0.6"
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,33 @@ Skip drawing black pixels for performance boost in UI applications. When
 enabled, calls to `set_pixel()` with `Color::BLACK` return early without
 writing to the framebuffer, assuming the framebuffer was already cleared.
 
+### `blank-delay-1` / `blank-delay-2` / `blank-delay-4` / `blank-delay-8`
+
+Control the number of pixel-clock cycles of blanking (`OE` HIGH) inserted around
+row address changes in the **plain** framebuffers (`plain` and `bitplane::plain`).
+The blanking delay gives the address lines time to settle before the new row is
+latched and lit, preventing ghosting or "bleeding" artifacts between rows.
+
+| Feature         | Blanking cycles |
+|-----------------|-----------------|
+| *(none)*        | 1 (default)     |
+| `blank-delay-1` | 1              |
+| `blank-delay-2` | 2              |
+| `blank-delay-4` | 4              |
+| `blank-delay-8` | 8              |
+
+Higher values reduce ghosting at the cost of slightly less brightness (the LEDs
+are on for less time per scan line). Start with the default and increase only if
+you observe row-transition artifacts on your particular panel hardware.
+
+```toml
+[dependencies]
+hub75-framebuffer = { version = "0.8.0", features = ["blank-delay-4"] }
+```
+
+**Note:** Only one `blank-delay-*` feature should be enabled at a time. If
+multiple are enabled, compile-time cfg conflicts will result.
+
 ### `defmt`
 
 Implement the `defmt::Format` trait so framebuffer types can be logged with

--- a/src/bitplane/plain.rs
+++ b/src/bitplane/plain.rs
@@ -78,6 +78,22 @@ use crate::FrameBuffer;
 use crate::WordSize;
 use crate::{FrameBufferOperations, MutableFrameBuffer};
 
+#[cfg(feature = "blank-delay-1")]
+const BLANKING_DELAY: usize = 1;
+#[cfg(feature = "blank-delay-2")]
+const BLANKING_DELAY: usize = 2;
+#[cfg(feature = "blank-delay-4")]
+const BLANKING_DELAY: usize = 4;
+#[cfg(feature = "blank-delay-8")]
+const BLANKING_DELAY: usize = 8;
+
+// Default to 1 if no blanking delay feature is enabled
+#[cfg(not(any(
+    feature = "blank-delay-1",
+    feature = "blank-delay-2",
+    feature = "blank-delay-4",
+    feature = "blank-delay-8"
+)))]
 const BLANKING_DELAY: usize = 1;
 
 #[inline]
@@ -101,7 +117,7 @@ const fn make_data_template<const COLS: usize>(addr: u8, prev_addr: u8) -> [Entr
         let mut entry = Entry::new();
         entry.0 = prev_addr as u16;
 
-        if i == 1 {
+        if i == BLANKING_DELAY {
             entry.0 |= 0b1_0000_0000; // OE
         } else if i == COLS - BLANKING_DELAY - 1 {
             // OE stays false

--- a/src/plain.rs
+++ b/src/plain.rs
@@ -141,6 +141,22 @@ use super::Color;
 use super::FrameBuffer;
 use super::WordSize;
 
+#[cfg(feature = "blank-delay-1")]
+const BLANKING_DELAY: usize = 1;
+#[cfg(feature = "blank-delay-2")]
+const BLANKING_DELAY: usize = 2;
+#[cfg(feature = "blank-delay-4")]
+const BLANKING_DELAY: usize = 4;
+#[cfg(feature = "blank-delay-8")]
+const BLANKING_DELAY: usize = 8;
+
+// Default to 1 if no blanking delay feature is enabled
+#[cfg(not(any(
+    feature = "blank-delay-1",
+    feature = "blank-delay-2",
+    feature = "blank-delay-4",
+    feature = "blank-delay-8"
+)))]
 const BLANKING_DELAY: usize = 1;
 
 /// Creates a pre-computed data template for a row with the specified addresses.


### PR DESCRIPTION
Features to allow adjusting the blanking time around row address changes to reduce ghosting.  

Related to: https://github.com/liebman/esp-hub75/issues/51